### PR TITLE
update import path to github

### DIFF
--- a/util.go
+++ b/util.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"path/filepath"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 )
 
 // ExecutablePath returns a system-native path to the currently running


### PR DESCRIPTION
`osext` moved to Github 2 days ago. I noticed this when my `go get` of resources-go failed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cookieo9/resources-go/4)
<!-- Reviewable:end -->
