### PR TITLE
update import path and travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ go:
  - 1.0
  - 1.1
  - 1.2
+ - 1.3
+ - 1.4
 
 install:
  - git clone https://github.com/kardianos/osext $HOME/gopath/src/github.com/kardianos/osext

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ go:
  - 1.2
 
 install:
- - hg clone https://bitbucket.org/kardianos/osext $HOME/gopath/src/bitbucket.org/kardianos/osext
+ - git clone https://github.com/kardianos/osext $HOME/gopath/src/github.com/kardianos/osext
  - go get -v ./...

--- a/util.go
+++ b/util.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"path/filepath"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 )
 
 // ExecutablePath returns a system-native path to the currently running
@@ -12,7 +12,7 @@ import (
 // NOTE: this function was intended to dissapear when it's functionality
 // would be handled by the stdlib (go issue 4057). Since that is less
 // likely to happen, I will probably leave this here leaving the API
-// alone. It is supported via the "bitbucket.org/kardianos/osext" package.
+// alone. It is supported via the "github.com/kardianos/osext" package.
 func ExecutablePath() (string, error) {
 	return osext.Executable()
 }


### PR DESCRIPTION
`osext` moved to Github. Go 1.3 and 1.4 have been released.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/cookieo9/resources-go/5)

<!-- Reviewable:end -->
